### PR TITLE
Use result of plane flip

### DIFF
--- a/src/dim3/bsp_node.rs
+++ b/src/dim3/bsp_node.rs
@@ -35,8 +35,8 @@ impl BspNode {
             p.flip();
         }
 
-        if self.plane.is_some() {
-            self.plane.as_mut().unwrap().flip();
+        if let Some(plane) = &mut self.plane {
+            *plane = plane.flip();
         }
 
         if self.front.is_some() {


### PR DESCRIPTION
This resolves issue #2.

`Plane::flip` is not mutative but was being called as if it was.

![image](https://user-images.githubusercontent.com/654931/114719755-646a0880-9d05-11eb-8d61-0479141858a4.png)

All existing examples now work.